### PR TITLE
GameStates - second attempt

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,0 +1,1 @@
+Run from Main class

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,20 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     </properties>
     <build>
+<plugins>
+<plugin>
+    <artifactId>maven-jar-plugin</artifactId>
+    <configuration>
+    <archive>
+    <manifest>
+    <addClasspath>true</addClasspath>
+    <mainClass>akademia.ox.Main</mainClass>
+    </manifest>
+    </archive>
+    </configuration>
+    </plugin>
 
+</plugins>
     </build>
 
     <dependencies>

--- a/src/main/java/akademia/ox/DrawState.java
+++ b/src/main/java/akademia/ox/DrawState.java
@@ -10,4 +10,9 @@ public class DrawState implements GameState {
     public boolean isGameOver() {
         return false;
     }
+
+    @Override
+    public String showStateInfo() {
+        return null;
+    }
 }

--- a/src/main/java/akademia/ox/DrawState.java
+++ b/src/main/java/akademia/ox/DrawState.java
@@ -1,0 +1,8 @@
+package akademia.ox;
+
+public class DrawState implements GameState {
+    @Override
+    public GameState moveToNextState() {
+        return null;
+    }
+}

--- a/src/main/java/akademia/ox/DrawState.java
+++ b/src/main/java/akademia/ox/DrawState.java
@@ -13,6 +13,6 @@ public class DrawState implements GameState {
 
     @Override
     public String showStateInfo() {
-        return null;
+        return StateInfo.DRAW_STATE.get();
     }
 }

--- a/src/main/java/akademia/ox/DrawState.java
+++ b/src/main/java/akademia/ox/DrawState.java
@@ -1,6 +1,8 @@
 package akademia.ox;
 
 public class DrawState implements GameState {
+
+
     @Override
     public GameState moveToNextState() {
         return new FinalState();
@@ -14,5 +16,15 @@ public class DrawState implements GameState {
     @Override
     public String showStateInfo() {
         return StateInfo.DRAW_STATE.get();
+    }
+
+    @Override
+    public void consumeInput(String query) {
+
+    }
+
+    @Override
+    public String showQuestion() {
+        return StateQuestions.DRAW_STATE.get();
     }
 }

--- a/src/main/java/akademia/ox/DrawState.java
+++ b/src/main/java/akademia/ox/DrawState.java
@@ -5,4 +5,9 @@ public class DrawState implements GameState {
     public GameState moveToNextState() {
         return new FinalState();
     }
+
+    @Override
+    public boolean isGameOver() {
+        return false;
+    }
 }

--- a/src/main/java/akademia/ox/DrawState.java
+++ b/src/main/java/akademia/ox/DrawState.java
@@ -3,6 +3,6 @@ package akademia.ox;
 public class DrawState implements GameState {
     @Override
     public GameState moveToNextState() {
-        return null;
+        return new FinalState();
     }
 }

--- a/src/main/java/akademia/ox/FinalState.java
+++ b/src/main/java/akademia/ox/FinalState.java
@@ -1,8 +1,17 @@
 package akademia.ox;
 
 public class FinalState implements GameState {
+    private boolean isContinued;
+
     @Override
     public GameState moveToNextState() {
+        if (isContinued) {
+            return new InitialState();
+        }
         return null;
+    }
+
+    void setIsContinued() {
+        isContinued = true;
     }
 }

--- a/src/main/java/akademia/ox/FinalState.java
+++ b/src/main/java/akademia/ox/FinalState.java
@@ -8,10 +8,17 @@ public class FinalState implements GameState {
         if (isContinued) {
             return new InitialState();
         }
+        if (!isContinued) {
+            return new TerminateState();
+        }
         return null;
     }
 
     void setIsContinued() {
         isContinued = true;
+    }
+
+    void setIsNotContinued() {
+        isContinued = false;
     }
 }

--- a/src/main/java/akademia/ox/FinalState.java
+++ b/src/main/java/akademia/ox/FinalState.java
@@ -14,6 +14,11 @@ public class FinalState implements GameState {
         return null;
     }
 
+    @Override
+    public boolean isGameOver() {
+        return false;
+    }
+
     void setIsContinued() {
         isContinued = true;
     }

--- a/src/main/java/akademia/ox/FinalState.java
+++ b/src/main/java/akademia/ox/FinalState.java
@@ -19,6 +19,11 @@ public class FinalState implements GameState {
         return false;
     }
 
+    @Override
+    public String showStateInfo() {
+        return null;
+    }
+
     void setIsContinued() {
         isContinued = true;
     }

--- a/src/main/java/akademia/ox/FinalState.java
+++ b/src/main/java/akademia/ox/FinalState.java
@@ -1,17 +1,11 @@
 package akademia.ox;
 
 public class FinalState implements GameState {
-    private boolean isContinued;
+    private GameState nextState;
 
     @Override
     public GameState moveToNextState() {
-        if (isContinued) {
-            return new InitialState();
-        }
-        if (!isContinued) {
-            return new TerminateState();
-        }
-        return null;
+        return nextState;
     }
 
     @Override
@@ -24,11 +18,24 @@ public class FinalState implements GameState {
         return StateInfo.FINAL_STATE.get();
     }
 
-    void setIsContinued() {
-        isContinued = true;
+    @Override
+    public void consumeInput(String query) {
+        switch (query) {
+            case "continue":
+                nextState = new InitialState();
+                break;
+            case "end":
+                nextState = new TerminateState();
+                break;
+            default:
+                nextState = this;
+
+        }
     }
 
-    void setIsNotContinued() {
-        isContinued = false;
+    @Override
+    public String showQuestion() {
+        return StateQuestions.FINAL_STATE.get();
     }
+
 }

--- a/src/main/java/akademia/ox/FinalState.java
+++ b/src/main/java/akademia/ox/FinalState.java
@@ -21,7 +21,7 @@ public class FinalState implements GameState {
 
     @Override
     public String showStateInfo() {
-        return null;
+        return StateInfo.FINAL_STATE.get();
     }
 
     void setIsContinued() {

--- a/src/main/java/akademia/ox/FinalState.java
+++ b/src/main/java/akademia/ox/FinalState.java
@@ -1,8 +1,8 @@
 package akademia.ox;
 
-public class VictoryState implements GameState {
+public class FinalState implements GameState {
     @Override
     public GameState moveToNextState() {
-        return new FinalState();
+        return null;
     }
 }

--- a/src/main/java/akademia/ox/GameInProgress.java
+++ b/src/main/java/akademia/ox/GameInProgress.java
@@ -24,6 +24,11 @@ public class GameInProgress implements GameState {
         return false;
     }
 
+    @Override
+    public String showStateInfo() {
+        return null;
+    }
+
     private boolean checkVictory() {
         return isVictory && ! isDraw;
     }

--- a/src/main/java/akademia/ox/GameInProgress.java
+++ b/src/main/java/akademia/ox/GameInProgress.java
@@ -1,8 +1,24 @@
 package akademia.ox;
 
 public class GameInProgress implements GameState {
+    private boolean isDraw;
+    private boolean isVictory;
+
     @Override
     public GameState moveToNextState() {
-        return null;
+        if (isNoEnd()) {
+            return this;
+        } else {
+            return null;
+        }
+    }
+
+    private boolean isNoEnd() {
+        return ! isDraw && ! isVictory;
+    }
+
+    void setNoDrawNoVictory(){
+        isDraw = false;
+        isVictory = false;
     }
 }

--- a/src/main/java/akademia/ox/GameInProgress.java
+++ b/src/main/java/akademia/ox/GameInProgress.java
@@ -26,7 +26,7 @@ public class GameInProgress implements GameState {
 
     @Override
     public String showStateInfo() {
-        return null;
+        return StateInfo.GAME_IN_PROGRESS_STATE.get();
     }
 
     private boolean checkVictory() {

--- a/src/main/java/akademia/ox/GameInProgress.java
+++ b/src/main/java/akademia/ox/GameInProgress.java
@@ -8,9 +8,16 @@ public class GameInProgress implements GameState {
     public GameState moveToNextState() {
         if (isNoEnd()) {
             return this;
+        }
+        if (checkVictory()) {
+            return new VictoryState();
         } else {
             return null;
         }
+    }
+
+    private boolean checkVictory() {
+        return isVictory && ! isDraw;
     }
 
     private boolean isNoEnd() {
@@ -20,5 +27,10 @@ public class GameInProgress implements GameState {
     void setNoDrawNoVictory(){
         isDraw = false;
         isVictory = false;
+    }
+
+    void setVictory() {
+        isVictory = true;
+        isDraw = false;
     }
 }

--- a/src/main/java/akademia/ox/GameInProgress.java
+++ b/src/main/java/akademia/ox/GameInProgress.java
@@ -11,6 +11,9 @@ public class GameInProgress implements GameState {
         }
         if (checkVictory()) {
             return new VictoryState();
+        }
+        if (checkDraw()) {
+            return new DrawState();
         } else {
             return null;
         }
@@ -18,6 +21,10 @@ public class GameInProgress implements GameState {
 
     private boolean checkVictory() {
         return isVictory && ! isDraw;
+    }
+
+    private boolean checkDraw() {
+        return ! isVictory && isDraw;
     }
 
     private boolean isNoEnd() {
@@ -32,5 +39,10 @@ public class GameInProgress implements GameState {
     void setVictory() {
         isVictory = true;
         isDraw = false;
+    }
+
+    void setDraw() {
+        isDraw = true;
+        isVictory = false;
     }
 }

--- a/src/main/java/akademia/ox/GameInProgress.java
+++ b/src/main/java/akademia/ox/GameInProgress.java
@@ -1,22 +1,11 @@
 package akademia.ox;
 
 public class GameInProgress implements GameState {
-    private boolean isDraw;
-    private boolean isVictory;
+    private GameState nextState;
 
     @Override
     public GameState moveToNextState() {
-        if (isNoEnd()) {
-            return this;
-        }
-        if (checkVictory()) {
-            return new VictoryState();
-        }
-        if (checkDraw()) {
-            return new DrawState();
-        } else {
-            return null;
-        }
+        return nextState;
     }
 
     @Override
@@ -29,30 +18,26 @@ public class GameInProgress implements GameState {
         return StateInfo.GAME_IN_PROGRESS_STATE.get();
     }
 
-    private boolean checkVictory() {
-        return isVictory && ! isDraw;
+    @Override
+    public void consumeInput(String query) {
+        switch (query) {
+            case "victory":
+                nextState = new VictoryState();
+                break;
+            case "draw":
+                nextState = new DrawState();
+                break;
+            case "exit":
+                nextState = new FinalState();
+                break;
+            default:
+                nextState = this;
+        }
     }
 
-    private boolean checkDraw() {
-        return ! isVictory && isDraw;
+    @Override
+    public String showQuestion() {
+        return StateQuestions.GAME_IN_PROGRESS_STATE.get();
     }
 
-    private boolean isNoEnd() {
-        return ! isDraw && ! isVictory;
-    }
-
-    void setNoDrawNoVictory(){
-        isDraw = false;
-        isVictory = false;
-    }
-
-    void setVictory() {
-        isVictory = true;
-        isDraw = false;
-    }
-
-    void setDraw() {
-        isDraw = true;
-        isVictory = false;
-    }
 }

--- a/src/main/java/akademia/ox/GameInProgress.java
+++ b/src/main/java/akademia/ox/GameInProgress.java
@@ -19,6 +19,11 @@ public class GameInProgress implements GameState {
         }
     }
 
+    @Override
+    public boolean isGameOver() {
+        return false;
+    }
+
     private boolean checkVictory() {
         return isVictory && ! isDraw;
     }

--- a/src/main/java/akademia/ox/GameInProgress.java
+++ b/src/main/java/akademia/ox/GameInProgress.java
@@ -1,0 +1,8 @@
+package akademia.ox;
+
+public class GameInProgress implements GameState {
+    @Override
+    public GameState moveToNextState() {
+        return null;
+    }
+}

--- a/src/main/java/akademia/ox/GameState.java
+++ b/src/main/java/akademia/ox/GameState.java
@@ -4,4 +4,6 @@ public interface GameState {
     GameState moveToNextState();
 
     boolean isGameOver();
+
+    String showStateInfo();
 }

--- a/src/main/java/akademia/ox/GameState.java
+++ b/src/main/java/akademia/ox/GameState.java
@@ -2,4 +2,6 @@ package akademia.ox;
 
 public interface GameState {
     GameState moveToNextState();
+
+    boolean isGameOver();
 }

--- a/src/main/java/akademia/ox/GameState.java
+++ b/src/main/java/akademia/ox/GameState.java
@@ -6,4 +6,8 @@ public interface GameState {
     boolean isGameOver();
 
     String showStateInfo();
+
+    void consumeInput(String query);
+
+    String showQuestion();
 }

--- a/src/main/java/akademia/ox/GameState.java
+++ b/src/main/java/akademia/ox/GameState.java
@@ -1,0 +1,5 @@
+package akademia.ox;
+
+public interface GameState {
+    GameState moveToNextState();
+}

--- a/src/main/java/akademia/ox/InitialState.java
+++ b/src/main/java/akademia/ox/InitialState.java
@@ -1,0 +1,8 @@
+package akademia.ox;
+
+public class InitialState implements GameState {
+    @Override
+    public GameState moveToNextState() {
+        return new GameInProgress();
+    }
+}

--- a/src/main/java/akademia/ox/InitialState.java
+++ b/src/main/java/akademia/ox/InitialState.java
@@ -10,4 +10,9 @@ public class InitialState implements GameState {
     public boolean isGameOver() {
         return false;
     }
+
+    @Override
+    public String showStateInfo() {
+        return StateInfo.INITIAL_STATE.get();
+    }
 }

--- a/src/main/java/akademia/ox/InitialState.java
+++ b/src/main/java/akademia/ox/InitialState.java
@@ -15,4 +15,14 @@ public class InitialState implements GameState {
     public String showStateInfo() {
         return StateInfo.INITIAL_STATE.get();
     }
+
+    @Override
+    public void consumeInput(String query) {
+
+    }
+
+    @Override
+    public String showQuestion() {
+        return StateQuestions.INITIAL_STATE.get();
+    }
 }

--- a/src/main/java/akademia/ox/InitialState.java
+++ b/src/main/java/akademia/ox/InitialState.java
@@ -5,4 +5,9 @@ public class InitialState implements GameState {
     public GameState moveToNextState() {
         return new GameInProgress();
     }
+
+    @Override
+    public boolean isGameOver() {
+        return false;
+    }
 }

--- a/src/main/java/akademia/ox/Main.java
+++ b/src/main/java/akademia/ox/Main.java
@@ -2,6 +2,13 @@ package akademia.ox;
 
 public class Main {
     public static void main(String[] args) {
-        System.out.println("Tylko testy");
+        GameState state = new InitialState();
+        while (!state.isGameOver()) {
+            System.out.println(state.showStateInfo());
+            state = state.moveToNextState();
+            if (state.getClass().equals(GameInProgress.class)) {
+                ((GameInProgress) state).setVictory();
+            }
+        }
     }
 }

--- a/src/main/java/akademia/ox/Main.java
+++ b/src/main/java/akademia/ox/Main.java
@@ -3,10 +3,12 @@ package akademia.ox;
 public class Main {
     public static void main(String[] args) {
         GameState state = new InitialState();
+        int i = 0;
         while (!state.isGameOver()) {
             System.out.println(state.showStateInfo());
             state = state.moveToNextState();
-            if (state.getClass().equals(GameInProgress.class)) {
+            i++;
+            if (i == 5) {
                 ((GameInProgress) state).setVictory();
             }
         }

--- a/src/main/java/akademia/ox/Main.java
+++ b/src/main/java/akademia/ox/Main.java
@@ -1,0 +1,7 @@
+package akademia.ox;
+
+public class Main {
+    public static void main(String[] args) {
+        System.out.println("Tylko testy");
+    }
+}

--- a/src/main/java/akademia/ox/Main.java
+++ b/src/main/java/akademia/ox/Main.java
@@ -6,7 +6,6 @@ public class Main {
     public static void main(String[] args) {
         Scanner in = new Scanner(System.in);
         GameState state = new InitialState();
-        int i = 0;
         while (!state.isGameOver()) {
             System.out.println(state.showStateInfo());
             System.out.println(state.showQuestion());

--- a/src/main/java/akademia/ox/Main.java
+++ b/src/main/java/akademia/ox/Main.java
@@ -1,16 +1,19 @@
 package akademia.ox;
 
+import java.util.Scanner;
+
 public class Main {
     public static void main(String[] args) {
+        Scanner in = new Scanner(System.in);
         GameState state = new InitialState();
         int i = 0;
         while (!state.isGameOver()) {
             System.out.println(state.showStateInfo());
+            System.out.println(state.showQuestion());
+            String answer = in.nextLine();
+            state.consumeInput(answer);
             state = state.moveToNextState();
-            i++;
-            if (i == 5) {
-                ((GameInProgress) state).setVictory();
-            }
+
         }
     }
 }

--- a/src/main/java/akademia/ox/StateInfo.java
+++ b/src/main/java/akademia/ox/StateInfo.java
@@ -3,8 +3,34 @@ package akademia.ox;
 public enum StateInfo {
 
     INITIAL_STATE {
+        @Override
         public String get() {
-            return "To jest początek gry";
+            return "To jest początek rundy";
+        }
+    }, GAME_IN_PROGRESS_STATE {
+        @Override
+        public String get() {
+            return "Runda jest w trakcie";
+        }
+    }, VICTORY_STATE {
+        @Override
+        public String get() {
+            return "Ktoś wygrał";
+        }
+    }, FINAL_STATE {
+        @Override
+        public String get() {
+            return "Runda zakończona";
+        }
+    }, TERMINATE_STATE {
+        @Override
+        public String get() {
+            return "Gra zakończona";
+        }
+    }, DRAW_STATE {
+        @Override
+        public String get() {
+            return "Jest remis";
         }
     };
 

--- a/src/main/java/akademia/ox/StateInfo.java
+++ b/src/main/java/akademia/ox/StateInfo.java
@@ -1,0 +1,12 @@
+package akademia.ox;
+
+public enum StateInfo {
+
+    INITIAL_STATE {
+        public String get() {
+            return "To jest początek gry";
+        }
+    };
+
+    public abstract String get();
+}

--- a/src/main/java/akademia/ox/StateQuestions.java
+++ b/src/main/java/akademia/ox/StateQuestions.java
@@ -5,17 +5,17 @@ public enum StateQuestions  {
     INITIAL_STATE {
         @Override
         public String get() {
-            return "Wpisz cokolwiek";
+            return "Wpisz cokolwiek, aby rozpocząć rundę (tu będą ustawienia rundy)";
         }
     }, GAME_IN_PROGRESS_STATE {
         @Override
         public String get() {
-            return "Wpisz victory, jeśli ma być zwycięstwo; Wpisz draw jeśli ma być remis, wpisz exit, aby zakończyć grę, wpisz cokolwiek, aby kontynuować rozgrywkę";
+            return "Wpisz victory, jeśli ma być zwycięstwo; Wpisz draw jeśli ma być remis, wpisz exit, aby zakończyć rundę 'walkowerem', wpisz cokolwiek, aby kontynuować rozgrywkę";
         }
     }, VICTORY_STATE {
         @Override
         public String get() {
-            return "Wpisz cokolwiek";
+            return "Wpisz cokolwiek, aby przejsć do podsumowania";
         }
     }, FINAL_STATE {
         @Override
@@ -30,7 +30,7 @@ public enum StateQuestions  {
     }, DRAW_STATE {
         @Override
         public String get() {
-            return "Wpisz cokolwiek";
+            return "Wpisz cokolwiek, aby przejść do podsumowania";
         }
     };
 

--- a/src/main/java/akademia/ox/StateQuestions.java
+++ b/src/main/java/akademia/ox/StateQuestions.java
@@ -1,36 +1,36 @@
 package akademia.ox;
 
-public enum StateInfo  {
+public enum StateQuestions  {
 
     INITIAL_STATE {
         @Override
         public String get() {
-            return "To jest początek rundy";
+            return "Wpisz cokolwiek";
         }
     }, GAME_IN_PROGRESS_STATE {
         @Override
         public String get() {
-            return "Runda jest w trakcie";
+            return "Wpisz victory, jeśli ma być zwycięstwo; Wpisz draw jeśli ma być remis, wpisz exit, aby zakończyć grę, wpisz cokolwiek, aby kontynuować rozgrywkę";
         }
     }, VICTORY_STATE {
         @Override
         public String get() {
-            return "Ktoś wygrał";
+            return "Wpisz cokolwiek";
         }
     }, FINAL_STATE {
         @Override
         public String get() {
-            return "Runda zakończona";
+            return "Wpisz end, aby zakończyć grę, wpisz continue, aby kontynować";
         }
     }, TERMINATE_STATE {
         @Override
         public String get() {
-            return "Gra zakończona";
+            return "";
         }
     }, DRAW_STATE {
         @Override
         public String get() {
-            return "Jest remis";
+            return "Wpisz cokolwiek";
         }
     };
 

--- a/src/main/java/akademia/ox/TerminateState.java
+++ b/src/main/java/akademia/ox/TerminateState.java
@@ -10,4 +10,9 @@ public class TerminateState implements GameState {
     public boolean isGameOver() {
         return true;
     }
+
+    @Override
+    public String showStateInfo() {
+        return null;
+    }
 }

--- a/src/main/java/akademia/ox/TerminateState.java
+++ b/src/main/java/akademia/ox/TerminateState.java
@@ -15,4 +15,14 @@ public class TerminateState implements GameState {
     public String showStateInfo() {
         return StateInfo.TERMINATE_STATE.get();
     }
+
+    @Override
+    public void consumeInput(String query) {
+
+    }
+
+    @Override
+    public String showQuestion() {
+        return StateQuestions.TERMINATE_STATE.get();
+    }
 }

--- a/src/main/java/akademia/ox/TerminateState.java
+++ b/src/main/java/akademia/ox/TerminateState.java
@@ -13,6 +13,6 @@ public class TerminateState implements GameState {
 
     @Override
     public String showStateInfo() {
-        return null;
+        return StateInfo.TERMINATE_STATE.get();
     }
 }

--- a/src/main/java/akademia/ox/TerminateState.java
+++ b/src/main/java/akademia/ox/TerminateState.java
@@ -5,4 +5,9 @@ public class TerminateState implements GameState {
     public GameState moveToNextState() {
         return null;
     }
+
+    @Override
+    public boolean isGameOver() {
+        return true;
+    }
 }

--- a/src/main/java/akademia/ox/TerminateState.java
+++ b/src/main/java/akademia/ox/TerminateState.java
@@ -1,0 +1,8 @@
+package akademia.ox;
+
+public class TerminateState implements GameState {
+    @Override
+    public GameState moveToNextState() {
+        return null;
+    }
+}

--- a/src/main/java/akademia/ox/VictoryState.java
+++ b/src/main/java/akademia/ox/VictoryState.java
@@ -1,0 +1,8 @@
+package akademia.ox;
+
+public class VictoryState implements GameState {
+    @Override
+    public GameState moveToNextState() {
+        return null;
+    }
+}

--- a/src/main/java/akademia/ox/VictoryState.java
+++ b/src/main/java/akademia/ox/VictoryState.java
@@ -15,4 +15,14 @@ public class VictoryState implements GameState {
     public String showStateInfo() {
         return StateInfo.VICTORY_STATE.get();
     }
+
+    @Override
+    public void consumeInput(String query) {
+
+    }
+
+    @Override
+    public String showQuestion() {
+        return StateQuestions.VICTORY_STATE.get();
+    }
 }

--- a/src/main/java/akademia/ox/VictoryState.java
+++ b/src/main/java/akademia/ox/VictoryState.java
@@ -10,4 +10,9 @@ public class VictoryState implements GameState {
     public boolean isGameOver() {
         return false;
     }
+
+    @Override
+    public String showStateInfo() {
+        return null;
+    }
 }

--- a/src/main/java/akademia/ox/VictoryState.java
+++ b/src/main/java/akademia/ox/VictoryState.java
@@ -13,6 +13,6 @@ public class VictoryState implements GameState {
 
     @Override
     public String showStateInfo() {
-        return null;
+        return StateInfo.VICTORY_STATE.get();
     }
 }

--- a/src/main/java/akademia/ox/VictoryState.java
+++ b/src/main/java/akademia/ox/VictoryState.java
@@ -5,4 +5,9 @@ public class VictoryState implements GameState {
     public GameState moveToNextState() {
         return new FinalState();
     }
+
+    @Override
+    public boolean isGameOver() {
+        return false;
+    }
 }

--- a/src/test/java/akademia/ox/StateMachineTests.java
+++ b/src/test/java/akademia/ox/StateMachineTests.java
@@ -16,7 +16,7 @@ public class StateMachineTests {
     }
 
     @Test
-    public void GameInProgressState_afterCallingMoveToNextStateIfThereIsNoDrawOrVictory_moveAgainToGameInProgressState() {
+    public void GameInProgressState_afterCallingMoveToNextStateIfThereIsNoDrawOrVictory_moveAgainToTheSameGameInProgressState() {
         //given
         GameInProgress gameInProgress = new GameInProgress();
         gameInProgress.setNoDrawNoVictory();
@@ -24,6 +24,7 @@ public class StateMachineTests {
         GameState nextState = gameInProgress.moveToNextState();
         //then
         Assert.assertEquals(nextState.getClass(), GameInProgress.class);
+        Assert.assertEquals(nextState, gameInProgress);
     }
 
     @Test
@@ -35,5 +36,16 @@ public class StateMachineTests {
         GameState nextState = gameInProgress.moveToNextState();
         //then
         Assert.assertEquals(nextState.getClass(), VictoryState.class);
+    }
+
+    @Test
+    public void GameInProgressState_afterCallingMoveToNextStateIfThereIsDraw_moveToDrawState() {
+        //given
+        GameInProgress gameInProgress = new GameInProgress();
+        gameInProgress.setDraw();
+        //when
+        GameState nextState = gameInProgress.moveToNextState();
+        //then
+        Assert.assertEquals(nextState.getClass(), DrawState.class);
     }
 }

--- a/src/test/java/akademia/ox/StateMachineTests.java
+++ b/src/test/java/akademia/ox/StateMachineTests.java
@@ -90,4 +90,12 @@ public class StateMachineTests {
         //then
         Assert.assertEquals(nextState.getClass(), TerminateState.class);
     }
+
+    @Test
+    public void TerminateState_informsThatGameIsOver() {
+        //given
+        TerminateState finalState = new TerminateState();
+        //then
+        Assert.assertTrue(finalState.isGameOver());
+    }
 }

--- a/src/test/java/akademia/ox/StateMachineTests.java
+++ b/src/test/java/akademia/ox/StateMachineTests.java
@@ -1,0 +1,17 @@
+package akademia.ox;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class StateMachineTests {
+
+    @Test
+    public void InitialState_afterCallingMoveToNextState_moveToGameInProgressState() {
+        //given
+        GameState initialState = new InitialState();
+        //when
+        GameState nextState = initialState.moveToNextState();
+        //then
+        Assert.assertEquals(nextState.getClass(), GameInProgress.class);
+    }
+}

--- a/src/test/java/akademia/ox/StateMachineTests.java
+++ b/src/test/java/akademia/ox/StateMachineTests.java
@@ -102,12 +102,62 @@ public class StateMachineTests {
     @Test
     public void InitialState_afterCallingShowState_returnsInformationAboutItsState() {
         //given
-        InitialState initialState = new InitialState();
+        GameState stateToTest = new InitialState();
         //when
-        String stateInfo = initialState.showStateInfo();
-        String initialStateInfo = StateInfo.INITIAL_STATE.get();
+        String stateInfo = stateToTest.showStateInfo();
+        String expectedStateInfo = StateInfo.INITIAL_STATE.get();
         //then
-        Assert.assertEquals(stateInfo, initialStateInfo);
+        Assert.assertEquals(stateInfo, expectedStateInfo);
 
     }
+
+    @Test
+    public void DrawState_afterCallingShowState_returnsInformationAboutItsState() {
+        //given
+        GameState stateToTest = new DrawState();
+        //when
+        String stateInfo = stateToTest.showStateInfo();
+        String expectedStateInfo = StateInfo.DRAW_STATE.get();
+        //then
+        Assert.assertEquals(stateInfo, expectedStateInfo);
+
+    }
+
+    @Test
+    public void VictoryState_afterCallingShowState_returnsInformationAboutItsState() {
+        //given
+        GameState stateToTest = new VictoryState();
+        //when
+        String stateInfo = stateToTest.showStateInfo();
+        String expectedStateInfo = StateInfo.VICTORY_STATE.get();
+        //then
+        Assert.assertEquals(stateInfo, expectedStateInfo);
+
+    }
+
+    @Test
+    public void FinalState_afterCallingShowState_returnsInformationAboutItsState() {
+        //given
+        GameState stateToTest = new FinalState();
+        //when
+        String stateInfo = stateToTest.showStateInfo();
+        String expectedStateInfo = StateInfo.FINAL_STATE.get();
+        //then
+        Assert.assertEquals(stateInfo, expectedStateInfo);
+
+    }
+
+    @Test
+    public void TerminateState_afterCallingShowState_returnsInformationAboutItsState() {
+        //given
+        GameState stateToTest = new TerminateState();
+        //when
+        String stateInfo = stateToTest.showStateInfo();
+        String expectedStateInfo = StateInfo.TERMINATE_STATE.get();
+        //then
+        Assert.assertEquals(stateInfo, expectedStateInfo);
+
+    }
+
+
 }

--- a/src/test/java/akademia/ox/StateMachineTests.java
+++ b/src/test/java/akademia/ox/StateMachineTests.java
@@ -79,4 +79,15 @@ public class StateMachineTests {
         //then
         Assert.assertEquals(nextState.getClass(), InitialState.class);
     }
+
+    @Test
+    public void FinalState_afterCallingMoveToNextStateIfGameIsNotContinued_moveTerminateState() {
+        //given
+        FinalState finalState = new FinalState();
+        //when
+        finalState.setIsNotContinued();
+        GameState nextState = finalState.moveToNextState();
+        //then
+        Assert.assertEquals(nextState.getClass(), TerminateState.class);
+    }
 }

--- a/src/test/java/akademia/ox/StateMachineTests.java
+++ b/src/test/java/akademia/ox/StateMachineTests.java
@@ -103,6 +103,17 @@ public class StateMachineTests {
     }
 
     @Test
+    public void FinalState_afterCallingMoveToNextStateIfInputIsIncorrect_stayInFinalState() {
+        //given
+        FinalState finalState = new FinalState();
+        //when
+        finalState.consumeInput("incorrectInput");
+        GameState nextState = finalState.moveToNextState();
+        //then
+        Assert.assertEquals(nextState.getClass(), FinalState.class);
+    }
+
+    @Test
     public void TerminateState_informsThatGameIsOver() {
         //given
         TerminateState finalState = new TerminateState();

--- a/src/test/java/akademia/ox/StateMachineTests.java
+++ b/src/test/java/akademia/ox/StateMachineTests.java
@@ -25,4 +25,15 @@ public class StateMachineTests {
         //then
         Assert.assertEquals(nextState.getClass(), GameInProgress.class);
     }
+
+    @Test
+    public void GameInProgressState_afterCallingMoveToNextStateIfThereIsVictory_moveToVictoryState() {
+        //given
+        GameInProgress gameInProgress = new GameInProgress();
+        gameInProgress.setVictory();
+        //when
+        GameState nextState = gameInProgress.moveToNextState();
+        //then
+        Assert.assertEquals(nextState.getClass(), VictoryState.class);
+    }
 }

--- a/src/test/java/akademia/ox/StateMachineTests.java
+++ b/src/test/java/akademia/ox/StateMachineTests.java
@@ -14,4 +14,15 @@ public class StateMachineTests {
         //then
         Assert.assertEquals(nextState.getClass(), GameInProgress.class);
     }
+
+    @Test
+    public void GameInProgressState_afterCallingMoveToNextStateIfThereIsNoDrawOrVictory_moveAgainToGameInProgressState() {
+        //given
+        GameInProgress gameInProgress = new GameInProgress();
+        gameInProgress.setNoDrawNoVictory();
+        //when
+        GameState nextState = gameInProgress.moveToNextState();
+        //then
+        Assert.assertEquals(nextState.getClass(), GameInProgress.class);
+    }
 }

--- a/src/test/java/akademia/ox/StateMachineTests.java
+++ b/src/test/java/akademia/ox/StateMachineTests.java
@@ -19,7 +19,7 @@ public class StateMachineTests {
     public void GameInProgressState_afterCallingMoveToNextStateIfThereIsNoDrawOrVictory_moveAgainToTheSameGameInProgressState() {
         //given
         GameInProgress gameInProgress = new GameInProgress();
-        gameInProgress.setNoDrawNoVictory();
+        gameInProgress.consumeInput("asdf");
         //when
         GameState nextState = gameInProgress.moveToNextState();
         //then
@@ -31,8 +31,8 @@ public class StateMachineTests {
     public void GameInProgressState_afterCallingMoveToNextStateIfThereIsVictory_moveToVictoryState() {
         //given
         GameInProgress gameInProgress = new GameInProgress();
-        gameInProgress.setVictory();
         //when
+        gameInProgress.consumeInput("victory");
         GameState nextState = gameInProgress.moveToNextState();
         //then
         Assert.assertEquals(nextState.getClass(), VictoryState.class);
@@ -42,11 +42,22 @@ public class StateMachineTests {
     public void GameInProgressState_afterCallingMoveToNextStateIfThereIsDraw_moveToDrawState() {
         //given
         GameInProgress gameInProgress = new GameInProgress();
-        gameInProgress.setDraw();
+        gameInProgress.consumeInput("draw");
         //when
         GameState nextState = gameInProgress.moveToNextState();
         //then
         Assert.assertEquals(nextState.getClass(), DrawState.class);
+    }
+
+    @Test
+    public void GameInProgressState_afterCallingMoveToNextStateIfWantingToExit_moveToFinalState() {
+        //given
+        GameInProgress gameInProgress = new GameInProgress();
+        gameInProgress.consumeInput("exit");
+        //when
+        GameState nextState = gameInProgress.moveToNextState();
+        //then
+        Assert.assertEquals(nextState.getClass(), FinalState.class);
     }
 
     @Test
@@ -74,7 +85,7 @@ public class StateMachineTests {
         //given
         FinalState finalState = new FinalState();
         //when
-        finalState.setIsContinued();
+        finalState.consumeInput("continue");
         GameState nextState = finalState.moveToNextState();
         //then
         Assert.assertEquals(nextState.getClass(), InitialState.class);
@@ -85,7 +96,7 @@ public class StateMachineTests {
         //given
         FinalState finalState = new FinalState();
         //when
-        finalState.setIsNotContinued();
+        finalState.consumeInput("end");
         GameState nextState = finalState.moveToNextState();
         //then
         Assert.assertEquals(nextState.getClass(), TerminateState.class);
@@ -159,5 +170,65 @@ public class StateMachineTests {
 
     }
 
+
+    @Test
+    public void InitialState_afterCallingShowQuestion_returnsInformationAboutInputRequirements() {
+        //given
+        GameState stateToTest = new InitialState();
+        //when
+        String question = stateToTest.showQuestion();
+        String expectedQuestion = StateQuestions.INITIAL_STATE.get();
+        //then
+        Assert.assertEquals(question, expectedQuestion);
+
+    }
+
+    @Test
+    public void DrawState_afterCallingShowQuestion_returnsInformationAboutInputRequirements() {
+        //given
+        GameState stateToTest = new DrawState();
+        //when
+        String question = stateToTest.showQuestion();
+        String expectedQuestion = StateQuestions.DRAW_STATE.get();
+        //then
+        Assert.assertEquals(question, expectedQuestion);
+
+    }
+
+    @Test
+    public void VictoryState_afterCallingShowQuestion_returnsInformationAboutInputRequirements() {
+        //given
+        GameState stateToTest = new VictoryState();
+        //when
+        String question = stateToTest.showQuestion();
+        String expectedQuestion = StateQuestions.VICTORY_STATE.get();
+        //then
+        Assert.assertEquals(question, expectedQuestion);
+
+    }
+
+    @Test
+    public void FinalState_afterCallingShowQuestion_returnsInformationAboutInputRequirements() {
+        //given
+        GameState stateToTest = new FinalState();
+        //when
+        String question = stateToTest.showQuestion();
+        String expectedQuestion = StateQuestions.FINAL_STATE.get();
+        //then
+        Assert.assertEquals(question, expectedQuestion);
+
+    }
+
+    @Test
+    public void TerminateState_afterCallingShowQuestion_returnsInformationAboutInputRequirements() {
+        //given
+        GameState stateToTest = new TerminateState();
+        //when
+        String question = stateToTest.showQuestion();
+        String expectedQuestion = StateQuestions.TERMINATE_STATE.get();
+        //then
+        Assert.assertEquals(question, expectedQuestion);
+
+    }
 
 }

--- a/src/test/java/akademia/ox/StateMachineTests.java
+++ b/src/test/java/akademia/ox/StateMachineTests.java
@@ -58,4 +58,14 @@ public class StateMachineTests {
         //then
         Assert.assertEquals(nextState.getClass(), FinalState.class);
     }
+
+    @Test
+    public void DrawState_afterCallingMoveToNextState_moveFinalState() {
+        //given
+        DrawState drawState = new DrawState();
+        //when
+        GameState nextState = drawState.moveToNextState();
+        //then
+        Assert.assertEquals(nextState.getClass(), FinalState.class);
+    }
 }

--- a/src/test/java/akademia/ox/StateMachineTests.java
+++ b/src/test/java/akademia/ox/StateMachineTests.java
@@ -48,4 +48,14 @@ public class StateMachineTests {
         //then
         Assert.assertEquals(nextState.getClass(), DrawState.class);
     }
+
+    @Test
+    public void VictoryState_afterCallingMoveToNextState_moveFinalState() {
+        //given
+        VictoryState victoryState = new VictoryState();
+        //when
+        GameState nextState = victoryState.moveToNextState();
+        //then
+        Assert.assertEquals(nextState.getClass(), FinalState.class);
+    }
 }

--- a/src/test/java/akademia/ox/StateMachineTests.java
+++ b/src/test/java/akademia/ox/StateMachineTests.java
@@ -3,6 +3,7 @@ package akademia.ox;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
+
 public class StateMachineTests {
 
     @Test
@@ -119,6 +120,17 @@ public class StateMachineTests {
         TerminateState finalState = new TerminateState();
         //then
         Assert.assertTrue(finalState.isGameOver());
+    }
+
+    @Test
+    public void StatesWithoutTerminateState_informsThatGameIsNotOver() {
+        //given
+        GameState[] states = {new FinalState(), new DrawState(), new GameInProgress(), new InitialState(), new VictoryState()};
+        //when // then
+        for (GameState state : states) {
+            Assert.assertFalse(state.isGameOver());
+        }
+
     }
 
     @Test

--- a/src/test/java/akademia/ox/StateMachineTests.java
+++ b/src/test/java/akademia/ox/StateMachineTests.java
@@ -98,4 +98,16 @@ public class StateMachineTests {
         //then
         Assert.assertTrue(finalState.isGameOver());
     }
+
+    @Test
+    public void InitialState_afterCallingShowState_returnsInformationAboutItsState() {
+        //given
+        InitialState initialState = new InitialState();
+        //when
+        String stateInfo = initialState.showStateInfo();
+        String initialStateInfo = StateInfo.INITIAL_STATE.get();
+        //then
+        Assert.assertEquals(stateInfo, initialStateInfo);
+
+    }
 }

--- a/src/test/java/akademia/ox/StateMachineTests.java
+++ b/src/test/java/akademia/ox/StateMachineTests.java
@@ -68,4 +68,15 @@ public class StateMachineTests {
         //then
         Assert.assertEquals(nextState.getClass(), FinalState.class);
     }
+
+    @Test
+    public void FinalState_afterCallingMoveToNextStateIfGameIsContinued_moveInitialState() {
+        //given
+        FinalState finalState = new FinalState();
+        //when
+        finalState.setIsContinued();
+        GameState nextState = finalState.moveToNextState();
+        //then
+        Assert.assertEquals(nextState.getClass(), InitialState.class);
+    }
 }


### PR DESCRIPTION
Setters removed.
After running project, It is possible to move through all states by input correct statement (there are hints in output which ones).

States:
- **Initial state** - round parameters will be choosed here, move to Game In Progress;
- **Game In Progress** - the main state of round, it is possible to move to Draw and Victory state or to Final (if player want to quit);
- **Victory and Draw states** - the Final State is after them;
- **Final State** - round is over, asks about game continuation (move to Initial State) or exit (move to Terminate State);
- **Terminate State** - inform about the game is end.

Pom improved - project should be built correctly.
Code coverage - ca 80%.

GameState interface has methods for:
- display current state,
- ask for next input,
- consume input (and doing something with it),
- move to next state,
- check is game over.

Strings with information are collected in enums (I think it's to improve)
"Ifology" to impove too